### PR TITLE
fix : 로그인 시 쿠키 안가져오는 문제 확인

### DIFF
--- a/README.md
+++ b/README.md
@@ -2326,3 +2326,49 @@ npm ERR!   @material-ui/core@"^4.12.1" from the root project
 - 버튼 디자인 구현할 때 색상을 제외한 font-size, margin 등의 값이 겹치는 것은 class로 빼서 스타일이 적용가능하게끔 하기
 
 </details>
+
+<details>
+<summary>2021.11.21 ~ 22 login (Tony)</summary>
+
+### 로그인 연동
+
+- 현재 로그인 시 200으로 응답이 오지만 서버에서 보낸 쿠키를 저장하지 못 하고 있음
+  - SameSite: Lax
+
+### Things to do
+
+- [x] 로그인 후 메인페이지에서 창 안닫히는 현상 수정
+- [ ] 로그인 인식해서 헤더 UI 변경
+- [ ] 로그인 여부 리덕스에 저장
+  - react-query에서 로컬변수 관리하는 방법을 찾아보던가 리덕스로 관리해야 함
+  - 일단 임시로 true로 설정
+
+### 로그인 시 쿠키 못 가져오는 문제
+
+#### 도메인이 달라서 서로 withCredentials을 true로 설정해줘야함
+
+```typescript
+// utils/fetcher.ts
+axios.defaults.withCredentials = true;
+
+// redux/sagas/index.ts
+axios.defaults.withCredentials = true;
+```
+
+#### SSR에서 설정
+
+- [ ] 쿠키를 먼저 가져오는 것을 설정 한 이후에 진행할 예정
+  - [ ] https로 배포를 해야 될 것 같음
+
+### 백엔드 주소 변경
+
+```javascript
+// config/config.js
+export const backUrl = 'https://www.ark-inflearn.shop'; // 기존 : 'http://3.34.236.174';
+```
+
+### 참고
+
+- [도메인이 다를 때 cookie 전달하기](https://velog.io/@gth1123/%EB%8F%84%EB%A9%94%EC%9D%B8%EC%9D%B4-%EB%8B%A4%EB%A5%BC-%EB%95%8C-cookie-%EC%A0%84%EB%8B%AC%ED%95%98%EA%B8%B0)
+
+</details>

--- a/config/config.js
+++ b/config/config.js
@@ -1,1 +1,1 @@
-export const backUrl = 'http://3.34.236.174';
+export const backUrl = 'https://www.ark-inflearn.shop';

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -85,6 +85,8 @@ export default function LoginModal({ handleFindPasswordModal, onClose }: IProps)
   const mutation = useMutation(({ email, password }: ILogin) => requestLogin(email, password), {
     onSuccess: (res) => {
       console.log(res);
+      onClose(); // 로그인 창 닫기
+      // 리덕스에 로그인 여부 저장
       Router.replace('/');
     },
     onError: (err: AxiosError) => {

--- a/src/redux/sagas/index.ts
+++ b/src/redux/sagas/index.ts
@@ -1,6 +1,9 @@
 import { all, fork } from '@redux-saga/core/effects';
+import axios from 'axios';
 import lectureSaga from './lecture';
 import userSaga from './user';
+
+axios.defaults.withCredentials = true;
 
 export default function* rootSaga() {
   yield all([fork(userSaga), fork(lectureSaga)]);

--- a/src/utils/fetcher.ts
+++ b/src/utils/fetcher.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { backUrl } from '../../config/config';
 
+axios.defaults.withCredentials = true;
+
 export const createSignup = async (email: string, password: string) => {
   const res = await axios.post(`${backUrl}/api/v1/member`, { email, password });
   return res.data;


### PR DESCRIPTION
### 로그인 연동

- 현재 로그인 시 200으로 응답이 오지만 서버에서 보낸 쿠키를 저장하지 못 하고 있음
  - SameSite: Lax

### Things to do

- [x] 로그인 후 메인페이지에서 창 안닫히는 현상 수정
- [ ] 로그인 인식해서 헤더 UI 변경
- [ ] 로그인 여부 리덕스에 저장
  - react-query에서 로컬변수 관리하는 방법을 찾아보던가 리덕스로 관리해야 함
  - 일단 임시로 true로 설정

### 로그인 시 쿠키 못 가져오는 문제

#### 도메인이 달라서 서로 withCredentials을 true로 설정해줘야함

```typescript
// utils/fetcher.ts
axios.defaults.withCredentials = true;

// redux/sagas/index.ts
axios.defaults.withCredentials = true;
```

#### SSR에서 설정

- [ ] 쿠키를 먼저 가져오는 것을 설정 한 이후에 진행할 예정
  - [ ] https로 배포를 해야 될 것 같음

### 백엔드 주소 변경

```javascript
// config/config.js
export const backUrl = 'https://www.ark-inflearn.shop'; // 기존 : 'http://3.34.236.174';
```

### 참고

- [도메인이 다를 때 cookie 전달하기](https://velog.io/@gth1123/%EB%8F%84%EB%A9%94%EC%9D%B8%EC%9D%B4-%EB%8B%A4%EB%A5%BC-%EB%95%8C-cookie-%EC%A0%84%EB%8B%AC%ED%95%98%EA%B8%B0)